### PR TITLE
Revoke the tokens linked to the original request

### DIFF
--- a/handler/oauth2/flow_generic_code_token.go
+++ b/handler/oauth2/flow_generic_code_token.go
@@ -179,7 +179,7 @@ func (c *GenericCodeTokenEndpointHandler) HandleTokenEndpointRequest(ctx context
 	var ar fosite.Requester
 	if ar, err = c.Session(ctx, requester, signature); err != nil {
 		if ar != nil && (errors.Is(err, fosite.ErrInvalidatedAuthorizeCode) || errors.Is(err, fosite.ErrInvalidatedDeviceCode)) {
-			return c.revokeTokens(ctx, requester.GetID())
+			return c.revokeTokens(ctx, ar.GetID())
 		}
 
 		return err


### PR DESCRIPTION
This was not revoking the access tokens nor refresh tokens associated with the original authorize code. `ar` represents the request that is retrieved via the signature of the original authorize code. `requester` seems to be a placeholder.

other refs: https://github.com/ory/fosite/blob/8631deb35b30a927970c216a58985ab17e6e471d/handler/oauth2/flow_authorize_code_token.go#L32-L51
